### PR TITLE
OCPBUGS-29358: fix CronTab list page empty state and title

### DIFF
--- a/src/views/CronTabList/CronTabList.tsx
+++ b/src/views/CronTabList/CronTabList.tsx
@@ -42,13 +42,17 @@ import {
 
 type CronTabListProps = {
   namespace: string;
+  showTitle?: boolean;
 };
 
 type CronTabKebabProps = {
   obj: CronTabKind;
 };
 
-const CronTabList: React.FC<CronTabListProps> = ({ namespace }) => {
+const CronTabList: React.FC<CronTabListProps> = ({
+  namespace,
+  showTitle = true,
+}) => {
   const [cronTabs, loaded, loadError] = useK8sWatchResource<
     K8sResourceCommon[]
   >({
@@ -63,7 +67,7 @@ const CronTabList: React.FC<CronTabListProps> = ({ namespace }) => {
 
   return (
     <>
-      <ListPageHeader title={t("CronTabs")}>
+      <ListPageHeader title={showTitle ? t("CronTabs") : undefined}>
         <ListPageCreate groupVersionKind={cronTabGroupVersionKind}>
           {t("Create CronTab")}
         </ListPageCreate>
@@ -81,6 +85,7 @@ const CronTabList: React.FC<CronTabListProps> = ({ namespace }) => {
           loadError={loadError}
           columns={columns}
           Row={cronTabListRow}
+          label={t("CronTabs")}
         />
       </ListPageBody>
     </>


### PR DESCRIPTION
After:
![localhost_9000_k8s_all-namespaces_stable example com~v1~CronTab (1)](https://github.com/openshift/console-crontab-plugin/assets/895728/2f28c4fc-eb25-4ec9-b663-de5cb19014c5)
![localhost_9000_k8s_all-namespaces_stable example com~v1~CronTab](https://github.com/openshift/console-crontab-plugin/assets/895728/c7f7fe13-c29d-4bac-8b68-803ad47c9380)
