### PR TITLE
OCPBUGS-59418: fix improperly nested flags

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -23,10 +23,10 @@
         "group": "stable.example.com",
         "kind": "CronTab",
         "version": "v1"
-      },
-      "flags": {
-        "required": ["CRONTAB"]
       }
+    },
+    "flags": {
+      "required": ["CRONTAB"]
     }
   },
   {
@@ -39,10 +39,10 @@
       },
       "component": {
         "$codeRef": "CronTabList"
-      },
-      "flags": {
-        "required": ["CRONTAB"]
       }
+    },
+    "flags": {
+      "required": ["CRONTAB"]
     }
   },
   {
@@ -56,10 +56,10 @@
       },
       "template": {
         "$codeRef": "yamlTemplates.defaultCronTabYamlTemplate"
-      },
-      "flags": {
-        "required": ["CRONTAB"]
       }
+    },
+    "flags": {
+      "required": ["CRONTAB"]
     }
   },
   {
@@ -70,6 +70,9 @@
         "$codeRef": "CronTabForm"
       },
       "exact": true
+    },
+    "flags": {
+      "required": ["CRONTAB"]
     }
   },
   {


### PR DESCRIPTION
Now that https://issues.redhat.com/browse/OCPBUGS-58858 is fixed in console, move `flags` to the correct location so they work.

TODO:

- [x] add flag in the correct location to route added in #34 